### PR TITLE
Suppress context menu items for windows with no title

### DIFF
--- a/src/ContextMenu.cpp
+++ b/src/ContextMenu.cpp
@@ -310,6 +310,9 @@ bool addMenuItemForWindow(HMENU menu, HWND hwnd, unsigned int id, const BitmapHa
 {
     std::string title = WindowInfo::getTitle(hwnd);
     constexpr size_t maxTitleLength = 30;
+    if (title.length() < 1) {
+        return true;
+    }
     if (title.length() > maxTitleLength) {
         const std::string_view ellipsis = "...";
         title.resize(maxTitleLength - ellipsis.length());


### PR DESCRIPTION
I've always had the problem that the longer I have finestray running, the more "empty" entries show up in my context menu list. This simple patch suppresses any entries with no titles. I've been using it for a couple of days with no issues. I don't know if anyone else would have a problem with title-less windows being suppressed, but for me it works perfectly so I am hoping you will consider incorporating it into the code.

This is a proposed fix for #19 