### PR TITLE
Add awareness of virtual desktops so only the windows currently visible are shown in the context menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial public pre-release
 
 [unreleased]: https://github.com/benbuck/finestray/compare/v0.5...HEAD
+[0.5]: https://github.com/benbuck/finestray/compare/v0.5...v0.5
 [0.5]: https://github.com/benbuck/finestray/compare/v0.4...v0.5
 [0.4]: https://github.com/benbuck/finestray/compare/v0.3...v0.4
 [0.3]: https://github.com/benbuck/finestray/compare/v0.2...v0.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [unreleased]: https://github.com/benbuck/finestray/compare/v0.5...HEAD
 [0.5]: https://github.com/benbuck/finestray/compare/v0.5...v0.5
 [0.5]: https://github.com/benbuck/finestray/compare/v0.5...v0.5
+[0.5]: https://github.com/benbuck/finestray/compare/v0.5...v0.5
 [0.5]: https://github.com/benbuck/finestray/compare/v0.4...v0.5
 [0.4]: https://github.com/benbuck/finestray/compare/v0.3...v0.4
 [0.3]: https://github.com/benbuck/finestray/compare/v0.2...v0.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.5]: https://github.com/benbuck/finestray/compare/v0.5...v0.5
 [0.5]: https://github.com/benbuck/finestray/compare/v0.5...v0.5
 [0.5]: https://github.com/benbuck/finestray/compare/v0.5...v0.5
+[0.5]: https://github.com/benbuck/finestray/compare/v0.5...v0.5
 [0.5]: https://github.com/benbuck/finestray/compare/v0.4...v0.5
 [0.4]: https://github.com/benbuck/finestray/compare/v0.3...v0.4
 [0.3]: https://github.com/benbuck/finestray/compare/v0.2...v0.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [unreleased]: https://github.com/benbuck/finestray/compare/v0.5...HEAD
 [0.5]: https://github.com/benbuck/finestray/compare/v0.5...v0.5
+[0.5]: https://github.com/benbuck/finestray/compare/v0.5...v0.5
 [0.5]: https://github.com/benbuck/finestray/compare/v0.4...v0.5
 [0.4]: https://github.com/benbuck/finestray/compare/v0.3...v0.4
 [0.3]: https://github.com/benbuck/finestray/compare/v0.2...v0.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5] - 2026-03-26
+
+
+
 ## [0.4] - 2025-05-21
 
 - Remove poll interval setting
@@ -62,7 +66,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial public pre-release
 
-[unreleased]: https://github.com/benbuck/finestray/compare/v0.4...HEAD
+[unreleased]: https://github.com/benbuck/finestray/compare/v0.5...HEAD
+[0.5]: https://github.com/benbuck/finestray/compare/v0.4...v0.5
 [0.4]: https://github.com/benbuck/finestray/compare/v0.3...v0.4
 [0.3]: https://github.com/benbuck/finestray/compare/v0.2...v0.3
 [0.2]: https://github.com/benbuck/finestray/compare/v0.1...v0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.5]: https://github.com/benbuck/finestray/compare/v0.5...v0.5
 [0.5]: https://github.com/benbuck/finestray/compare/v0.5...v0.5
 [0.5]: https://github.com/benbuck/finestray/compare/v0.5...v0.5
+[0.5]: https://github.com/benbuck/finestray/compare/v0.5...v0.5
 [0.5]: https://github.com/benbuck/finestray/compare/v0.4...v0.5
 [0.4]: https://github.com/benbuck/finestray/compare/v0.3...v0.4
 [0.3]: https://github.com/benbuck/finestray/compare/v0.2...v0.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.5]: https://github.com/benbuck/finestray/compare/v0.5...v0.5
 [0.5]: https://github.com/benbuck/finestray/compare/v0.5...v0.5
 [0.5]: https://github.com/benbuck/finestray/compare/v0.5...v0.5
+[0.5]: https://github.com/benbuck/finestray/compare/v0.5...v0.5
 [0.5]: https://github.com/benbuck/finestray/compare/v0.4...v0.5
 [0.4]: https://github.com/benbuck/finestray/compare/v0.3...v0.4
 [0.3]: https://github.com/benbuck/finestray/compare/v0.2...v0.3

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,7 @@ target_compile_options(Finestray
                 /analyze # enable static analysis
                 /wd26485 # No array to pointer decay
                 /wd26490 # Don't use reinterpret_cast
+                /wd6553  # Windows SDK annotation bug: RegOpenKeyExW _Param_(3)
             >
         >
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
 endif()
 
 project(Finestray
-    VERSION 0.4
+    VERSION 0.5
 )
 
 add_executable(Finestray WIN32

--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ reduce visual clutter.
 There are three standard ways to get Finestray:
 
 1) Using the installer from the [Finestray release page](https://github.com/benbuck/finestray/releases). It's named
-   [Finestray-0.4-Win64.exe](https://github.com/benbuck/finestray/releases/download/v0.4/Finestray-0.4-win64.exe).
+   [Finestray-0.5-Win64.exe](https://github.com/benbuck/finestray/releases/download/v0.5/Finestray-0.5-win64.exe).
    Once you have downloaded the file, you will need to run it and go through the prompts to complete the installation.
    After installation completes, Finestray should launch automatically.
 2) Using the portable executable from [Finestray release page](https://github.com/benbuck/finestray/releases). The
    portable executable is named
-   [Finestray.exe](https://github.com/benbuck/finestray/releases/download/v0.4/Finestray.exe). Place it wherever you
+   [Finestray.exe](https://github.com/benbuck/finestray/releases/download/v0.5/Finestray.exe). Place it wherever you
    prefer on your system, and run it from there.
 3) Using winget. From a Windows shell (e.g. Command Prompt or Powershell): ```winget install finestray```. After
    installation completes, Finestray should launch automatically.

--- a/fix_path.ps1
+++ b/fix_path.ps1
@@ -1,0 +1,1 @@
+$ENV:PATH+=";C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin;C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\Llvm\x64\bin;C:\Program Files (x86)\NSIS;C:\Program Files (x86)\Microsoft Visual Studio\Installer;C:\Program Files\ImageMagick-7.1.2-Q16-HDRI"

--- a/fix_path.ps1
+++ b/fix_path.ps1
@@ -1,1 +1,0 @@
-$ENV:PATH+=";C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin;C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\Llvm\x64\bin;C:\Program Files (x86)\NSIS;C:\Program Files (x86)\Microsoft Visual Studio\Installer;C:\Program Files\ImageMagick-7.1.2-Q16-HDRI"

--- a/output.log
+++ b/output.log
@@ -1,0 +1,74 @@
+Updating version from 0.5 to 0.5
+Updating CHANGELOG.md
+Updating CMakeLists.txt
+Updating README.md
+Updating AppInfo.h
+Building
+
+C:\apps\src\finestray>setlocal enabledelayedexpansion 
+
+C:\apps\src\finestray>pushd C:\apps\src\finestray\ 
+
+C:\apps\src\finestray>call ninja-msvc-build.bat Debug 
+
+C:\apps\src\finestray>setlocal enabledelayedexpansion 
+
+C:\apps\src\finestray>set BUILD_CONFIG=Debug 
+
+C:\apps\src\finestray>if "Debug" == "" set BUILD_CONFIG=Debug 
+
+C:\apps\src\finestray>set BUILD_DIR=build\ninja-msvc\Debug 
+
+C:\apps\src\finestray>if not exist build\ninja-msvc\Debug mkdir build\ninja-msvc\Debug 
+
+C:\apps\src\finestray>pushd build\ninja-msvc\Debug 
+
+C:\apps\src\finestray\build\ninja-msvc\Debug>if not defined VCINSTALLDIR (
+rem get latest visual studio install location  
+ rem for /f "tokens=* USEBACKQ" %x in (`powershell -command "(Get-CimInstance MSFT_VSInstance | Select-Object -Last 1).InstallLocation"`) do set VSTUDIO_INSTALL_DIR=%x  
+ rem winget install vswhere  
+ for /F "tokens=* USEBACKQ" %x in (`vswhere -latest -property installationPath`) do set VSTUDIO_INSTALL_DIR=%x  
+ rem set environment for visual studio command line builds  
+ call "!VSTUDIO_INSTALL_DIR!\VC\Auxiliary\Build\vcvars64.bat" 
+) 
+
+C:\apps\src\finestray\build\ninja-msvc\Debug>set VSTUDIO_INSTALL_DIR=C:\Program Files\Microsoft Visual Studio\2022\Community 
+**********************************************************************
+** Visual Studio 2022 Developer Command Prompt v17.14.29
+** Copyright (c) 2025 Microsoft Corporation
+**********************************************************************
+[vcvarsall.bat] Environment initialized for: 'x64'
+-- Configuring done (0.5s)
+-- Generating done (0.1s)
+-- Build files have been written to: C:/apps/src/finestray/build/ninja-msvc/Debug
+[1/29] Building RC object CMakeFiles\Finestray.dir\src\Finestray.rc.res
+[2/29] Scanning C:\apps\src\finestray\src\Helpers.cpp for CXX dependencies
+[3/29] Scanning C:\apps\src\finestray\src\ContextMenu.cpp for CXX dependencies
+[4/29] Scanning C:\apps\src\finestray\src\Path.cpp for CXX dependencies
+[5/29] Scanning C:\apps\src\finestray\src\SettingsDialog.cpp for CXX dependencies
+[6/29] Scanning C:\apps\src\finestray\src\Settings.cpp for CXX dependencies
+[7/29] Scanning C:\apps\src\finestray\src\Finestray.cpp for CXX dependencies
+[8/29] Generating CXX dyndep file CMakeFiles\Finestray.dir\CXX.dd
+[9/15] Building CXX object CMakeFiles\Finestray.dir\src\Helpers.cpp.obj
+[10/15] Building CXX object CMakeFiles\Finestray.dir\src\Path.cpp.obj
+[11/15] Building CXX object CMakeFiles\Finestray.dir\src\ContextMenu.cpp.obj
+[12/15] Building CXX object CMakeFiles\Finestray.dir\src\SettingsDialog.cpp.obj
+[13/15] Building CXX object CMakeFiles\Finestray.dir\src\Settings.cpp.obj
+[14/15] Building CXX object CMakeFiles\Finestray.dir\src\Finestray.cpp.obj
+[15/15] Linking CXX executable Finestray.exe
+**********************************************************************
+** Visual Studio 2022 Developer Command Prompt v17.14.29
+** Copyright (c) 2025 Microsoft Corporation
+**********************************************************************
+[vcvarsall.bat] Environment initialized for: 'x64'
+-- Configuring done (0.5s)
+-- Generating done (0.1s)
+-- Build files have been written to: C:/apps/src/finestray/build/ninja-msvc/Release
+[1/29] Building RC object CMakeFiles\Finestray.dir\src\Finestray.rc.res
+[2/29] Scanning C:\apps\src\finestray\src\Helpers.cpp for CXX dependencies
+[3/29] Scanning C:\apps\src\finestray\src\ContextMenu.cpp for CXX dependencies
+[4/29] Scanning C:\apps\src\finestray\src\Path.cpp for CXX dependencies
+[5/29] Scanning C:\apps\src\finestray\src\SettingsDialog.cpp for CXX dependencies
+[6/29] Scanning C:\apps\src\finestray\src\Finestray.cpp for CXX dependencies
+[7/29] Scanning C:\apps\src\finestray\src\Settings.cpp for CXX dependencies
+[8/29] Generating CXX dyndep file CMakeFiles\Finestray.dir\CXX.dd

--- a/output.log
+++ b/output.log
@@ -228,3 +228,142 @@ CPack: - package: C:/apps/src/finestray/build/ninja-msvc/Release/Finestray-0.5-w
 -- Detecting CXX compile features
 -- Detecting CXX compile features - done
 -- Found Patch: C:/Program Files/Git/usr/bin/patch.exe
+-- Performing Test FLAG_SUPPORTED_stdc89
+-- Performing Test FLAG_SUPPORTED_stdc89 - Success
+-- Performing Test FLAG_SUPPORTED_pedantic
+-- Performing Test FLAG_SUPPORTED_pedantic - Success
+-- Performing Test FLAG_SUPPORTED_Wall
+-- Performing Test FLAG_SUPPORTED_Wall - Success
+-- Performing Test FLAG_SUPPORTED_Wextra
+-- Performing Test FLAG_SUPPORTED_Wextra - Success
+-- Performing Test FLAG_SUPPORTED_Werror
+-- Performing Test FLAG_SUPPORTED_Werror - Success
+-- Performing Test FLAG_SUPPORTED_Wstrictprototypes
+-- Performing Test FLAG_SUPPORTED_Wstrictprototypes - Success
+-- Performing Test FLAG_SUPPORTED_Wwritestrings
+-- Performing Test FLAG_SUPPORTED_Wwritestrings - Success
+-- Performing Test FLAG_SUPPORTED_Wshadow
+-- Performing Test FLAG_SUPPORTED_Wshadow - Success
+-- Performing Test FLAG_SUPPORTED_Winitself
+-- Performing Test FLAG_SUPPORTED_Winitself - Success
+-- Performing Test FLAG_SUPPORTED_Wcastalign
+-- Performing Test FLAG_SUPPORTED_Wcastalign - Success
+-- Performing Test FLAG_SUPPORTED_Wformat2
+-- Performing Test FLAG_SUPPORTED_Wformat2 - Success
+-- Performing Test FLAG_SUPPORTED_Wmissingprototypes
+-- Performing Test FLAG_SUPPORTED_Wmissingprototypes - Success
+-- Performing Test FLAG_SUPPORTED_Wstrictoverflow2
+-- Performing Test FLAG_SUPPORTED_Wstrictoverflow2 - Success
+-- Performing Test FLAG_SUPPORTED_Wcastqual
+-- Performing Test FLAG_SUPPORTED_Wcastqual - Success
+-- Performing Test FLAG_SUPPORTED_Wundef
+-- Performing Test FLAG_SUPPORTED_Wundef - Success
+-- Performing Test FLAG_SUPPORTED_Wswitchdefault
+-- Performing Test FLAG_SUPPORTED_Wswitchdefault - Success
+-- Performing Test FLAG_SUPPORTED_Wconversion
+-- Performing Test FLAG_SUPPORTED_Wconversion - Success
+-- Performing Test FLAG_SUPPORTED_Wccompat
+-- Performing Test FLAG_SUPPORTED_Wccompat - Success
+-- Performing Test FLAG_SUPPORTED_fstackprotectorstrong
+-- Performing Test FLAG_SUPPORTED_fstackprotectorstrong - Success
+-- Performing Test FLAG_SUPPORTED_Wcomma
+-- Performing Test FLAG_SUPPORTED_Wcomma - Success
+-- Performing Test FLAG_SUPPORTED_Wdoublepromotion
+-- Performing Test FLAG_SUPPORTED_Wdoublepromotion - Success
+-- Performing Test FLAG_SUPPORTED_Wparentheses
+-- Performing Test FLAG_SUPPORTED_Wparentheses - Success
+-- Performing Test FLAG_SUPPORTED_Wformatoverflow
+-- Performing Test FLAG_SUPPORTED_Wformatoverflow - Success
+-- Performing Test FLAG_SUPPORTED_Wunusedmacros
+-- Performing Test FLAG_SUPPORTED_Wunusedmacros - Success
+-- Performing Test FLAG_SUPPORTED_Wmissingvariabledeclarations
+-- Performing Test FLAG_SUPPORTED_Wmissingvariabledeclarations - Success
+-- Performing Test FLAG_SUPPORTED_Wusedbutmarkedunused
+-- Performing Test FLAG_SUPPORTED_Wusedbutmarkedunused - Success
+-- Performing Test FLAG_SUPPORTED_Wswitchenum
+-- Performing Test FLAG_SUPPORTED_Wswitchenum - Success
+-- Performing Test FLAG_SUPPORTED_fvisibilityhidden
+-- Performing Test FLAG_SUPPORTED_fvisibilityhidden - Success
+-- Configuring done (24.3s)
+-- Generating done (0.2s)
+-- Build files have been written to: C:/apps/src/finestray/build/ninja-clang/Release
+[1/57] Converting C:/apps/src/finestray/src/images/finestray.svg to C:/apps/src/finestray/build/ninja-clang/Release/app.bmp
+[2/57] Converting C:/apps/src/finestray/src/images/emoji_u274c.svg to C:/apps/src/finestray/build/ninja-clang/Release/exit.bmp
+[3/57] Converting C:/apps/src/finestray/src/images/emoji_u2198.svg to C:/apps/src/finestray/build/ninja-clang/Release/minimize.bmp
+[4/57] Converting C:/apps/src/finestray/src/images/emoji_u2196.svg to C:/apps/src/finestray/build/ninja-clang/Release/restore.bmp
+[5/57] Converting C:/apps/src/finestray/src/images/emoji_u2699.svg to C:/apps/src/finestray/build/ninja-clang/Release/settings.bmp
+[6/57] Converting C:/apps/src/finestray/src/images/finestray.svg to C:/apps/src/finestray/src/images/icon.png
+[7/57] Converting C:/apps/src/finestray/src/images/finestray.svg to C:/apps/src/finestray/build/ninja-clang/Release/installer_header.bmp
+[8/57] Converting C:/apps/src/finestray/src/images/finestray.svg to C:/apps/src/finestray/build/ninja-clang/Release/installer_welcome.bmp
+[9/57] Building C object _deps/cjson-build/CMakeFiles/cjson.dir/cJSON.c.obj
+[10/57] Converting C:/apps/src/finestray/src/images/finestray.svg to C:/apps/src/finestray/build/ninja-clang/Release/Finestray.ico
+[11/57] Linking C static library _deps\cjson-build\cjson.lib
+[12/57] Converting C:/apps/src/finestray/src/images/finestray.svg to C:/apps/src/finestray/build/ninja-clang/Release/logo-1440x2160.png
+[13/57] Building RC object CMakeFiles/Finestray.dir/src/Finestray.rc.res
+Microsoft (R) Windows (R) Resource Compiler Version 10.0.10011.16384
+
+
+Copyright (C) Microsoft Corporation.  All rights reserved.
+
+
+
+
+[14/57] Converting C:/apps/src/finestray/src/images/settings-window.png to C:/apps/src/finestray/build/ninja-clang/Release/screenshot-3840x2160.png
+[15/57] Converting C:/apps/src/finestray/src/images/finestray.svg to C:/apps/src/finestray/build/ninja-clang/Release/logo-2160x2160.png
+[16/57] Scanning C:/apps/src/finestray/src/AboutDialog.cpp for CXX dependencies
+[17/57] Scanning C:/apps/src/finestray/src/Hotkey.cpp for CXX dependencies
+[18/57] Scanning C:/apps/src/finestray/src/MinimizePlacement.cpp for CXX dependencies
+[19/57] Scanning C:/apps/src/finestray/src/MinimizePersistence.cpp for CXX dependencies
+[20/57] Scanning C:/apps/src/finestray/src/Finestray.cpp for CXX dependencies
+[21/57] Scanning C:/apps/src/finestray/src/ContextMenu.cpp for CXX dependencies
+[22/57] Scanning C:/apps/src/finestray/src/Helpers.cpp for CXX dependencies
+[23/57] Scanning C:/apps/src/finestray/src/Bitmap.cpp for CXX dependencies
+[24/57] Scanning C:/apps/src/finestray/src/File.cpp for CXX dependencies
+[25/57] Scanning C:/apps/src/finestray/src/Log.cpp for CXX dependencies
+[26/57] Scanning C:/apps/src/finestray/src/Path.cpp for CXX dependencies
+[27/57] Scanning C:/apps/src/finestray/src/TrayEvent.cpp for CXX dependencies
+[28/57] Scanning C:/apps/src/finestray/src/Modifiers.cpp for CXX dependencies
+[29/57] Scanning C:/apps/src/finestray/src/Settings.cpp for CXX dependencies
+[30/57] Scanning C:/apps/src/finestray/src/WindowIcon.cpp for CXX dependencies
+[31/57] Scanning C:/apps/src/finestray/src/SettingsDialog.cpp for CXX dependencies
+[32/57] Scanning C:/apps/src/finestray/src/WindowInfo.cpp for CXX dependencies
+[33/57] Scanning C:/apps/src/finestray/src/StringUtility.cpp for CXX dependencies
+[34/57] Scanning C:/apps/src/finestray/src/TrayIcon.cpp for CXX dependencies
+[35/57] Scanning C:/apps/src/finestray/src/WindowTracker.cpp for CXX dependencies
+[36/57] Generating CXX dyndep file CMakeFiles/Finestray.dir/CXX.dd
+[37/57] Building CXX object CMakeFiles/Finestray.dir/src/MinimizePersistence.cpp.obj
+[38/57] Building CXX object CMakeFiles/Finestray.dir/src/MinimizePlacement.cpp.obj
+[39/57] Building CXX object CMakeFiles/Finestray.dir/src/TrayEvent.cpp.obj
+[40/57] Building CXX object CMakeFiles/Finestray.dir/src/AboutDialog.cpp.obj
+[41/57] Building CXX object CMakeFiles/Finestray.dir/src/WindowIcon.cpp.obj
+[42/57] Building CXX object CMakeFiles/Finestray.dir/src/Helpers.cpp.obj
+[43/57] Building CXX object CMakeFiles/Finestray.dir/src/Bitmap.cpp.obj
+[44/57] Building CXX object CMakeFiles/Finestray.dir/src/File.cpp.obj
+[45/57] Building CXX object CMakeFiles/Finestray.dir/src/Modifiers.cpp.obj
+[46/57] Building CXX object CMakeFiles/Finestray.dir/src/Log.cpp.obj
+[47/57] Building CXX object CMakeFiles/Finestray.dir/src/ContextMenu.cpp.obj
+[48/57] Building CXX object CMakeFiles/Finestray.dir/src/Hotkey.cpp.obj
+[49/57] Building CXX object CMakeFiles/Finestray.dir/src/WindowInfo.cpp.obj
+[50/57] Building CXX object CMakeFiles/Finestray.dir/src/Path.cpp.obj
+[51/57] Building CXX object CMakeFiles/Finestray.dir/src/TrayIcon.cpp.obj
+[52/57] Building CXX object CMakeFiles/Finestray.dir/src/StringUtility.cpp.obj
+[53/57] Building CXX object CMakeFiles/Finestray.dir/src/SettingsDialog.cpp.obj
+[54/57] Building CXX object CMakeFiles/Finestray.dir/src/WindowTracker.cpp.obj
+[55/57] Building CXX object CMakeFiles/Finestray.dir/src/Settings.cpp.obj
+[56/57] Building CXX object CMakeFiles/Finestray.dir/src/Finestray.cpp.obj
+[57/57] Linking CXX executable Finestray.exe
+[0/1] Run CPack packaging tool...
+CPack: Create package using NSIS64
+CPack: Install projects
+CPack: - Install project: Finestray []
+CPack: Create package
+CPack: - package: C:/apps/src/finestray/build/ninja-clang/Release/Finestray-0.5-win64.exe generated.
+CMake is re-running because C:/apps/src/temp/finestray/build/vstudio-msvc/CMakeFiles/generate.stamp dependency file is missing.
+Build failed
+Starting new version, please exit when done testing
+Starting new installer, please exit when done installing
+
+Updating version in git
+[virtual-desktops cbe82bb] Update version to 0.5
+ 4 files changed, 185 insertions(+), 32 deletions(-)
+Updated tag 'v0.5' (was 478c8b9)

--- a/output.log
+++ b/output.log
@@ -38,24 +38,44 @@ C:\apps\src\finestray\build\ninja-msvc\Debug>set VSTUDIO_INSTALL_DIR=C:\Program 
 ** Copyright (c) 2025 Microsoft Corporation
 **********************************************************************
 [vcvarsall.bat] Environment initialized for: 'x64'
--- Configuring done (0.5s)
+-- Configuring done (0.6s)
 -- Generating done (0.1s)
 -- Build files have been written to: C:/apps/src/finestray/build/ninja-msvc/Debug
-[1/29] Building RC object CMakeFiles\Finestray.dir\src\Finestray.rc.res
-[2/29] Scanning C:\apps\src\finestray\src\Helpers.cpp for CXX dependencies
-[3/29] Scanning C:\apps\src\finestray\src\ContextMenu.cpp for CXX dependencies
-[4/29] Scanning C:\apps\src\finestray\src\Path.cpp for CXX dependencies
-[5/29] Scanning C:\apps\src\finestray\src\SettingsDialog.cpp for CXX dependencies
-[6/29] Scanning C:\apps\src\finestray\src\Settings.cpp for CXX dependencies
-[7/29] Scanning C:\apps\src\finestray\src\Finestray.cpp for CXX dependencies
-[8/29] Generating CXX dyndep file CMakeFiles\Finestray.dir\CXX.dd
-[9/15] Building CXX object CMakeFiles\Finestray.dir\src\Helpers.cpp.obj
-[10/15] Building CXX object CMakeFiles\Finestray.dir\src\Path.cpp.obj
-[11/15] Building CXX object CMakeFiles\Finestray.dir\src\ContextMenu.cpp.obj
-[12/15] Building CXX object CMakeFiles\Finestray.dir\src\SettingsDialog.cpp.obj
-[13/15] Building CXX object CMakeFiles\Finestray.dir\src\Settings.cpp.obj
-[14/15] Building CXX object CMakeFiles\Finestray.dir\src\Finestray.cpp.obj
-[15/15] Linking CXX executable Finestray.exe
+[1/39] Scanning C:\apps\src\finestray\src\Log.cpp for CXX dependencies
+[2/39] Scanning C:\apps\src\finestray\src\TrayIcon.cpp for CXX dependencies
+[3/39] Scanning C:\apps\src\finestray\src\Bitmap.cpp for CXX dependencies
+[4/39] Scanning C:\apps\src\finestray\src\File.cpp for CXX dependencies
+[5/39] Scanning C:\apps\src\finestray\src\SettingsDialog.cpp for CXX dependencies
+[6/39] Scanning C:\apps\src\finestray\src\Helpers.cpp for CXX dependencies
+[7/39] Scanning C:\apps\src\finestray\src\Modifiers.cpp for CXX dependencies
+[8/39] Scanning C:\apps\src\finestray\src\StringUtility.cpp for CXX dependencies
+[9/39] Scanning C:\apps\src\finestray\src\AboutDialog.cpp for CXX dependencies
+[10/39] Scanning C:\apps\src\finestray\src\Hotkey.cpp for CXX dependencies
+[11/39] Building RC object CMakeFiles\Finestray.dir\src\Finestray.rc.res
+[12/39] Scanning C:\apps\src\finestray\src\WindowTracker.cpp for CXX dependencies
+[13/39] Scanning C:\apps\src\finestray\src\Path.cpp for CXX dependencies
+[14/39] Scanning C:\apps\src\finestray\src\ContextMenu.cpp for CXX dependencies
+[15/39] Scanning C:\apps\src\finestray\src\Settings.cpp for CXX dependencies
+[16/39] Scanning C:\apps\src\finestray\src\WindowInfo.cpp for CXX dependencies
+[17/39] Scanning C:\apps\src\finestray\src\Finestray.cpp for CXX dependencies
+[18/39] Generating CXX dyndep file CMakeFiles\Finestray.dir\CXX.dd
+[19/35] Building CXX object CMakeFiles\Finestray.dir\src\Modifiers.cpp.obj
+[20/35] Building CXX object CMakeFiles\Finestray.dir\src\Bitmap.cpp.obj
+[21/35] Building CXX object CMakeFiles\Finestray.dir\src\AboutDialog.cpp.obj
+[22/35] Building CXX object CMakeFiles\Finestray.dir\src\File.cpp.obj
+[23/35] Building CXX object CMakeFiles\Finestray.dir\src\Helpers.cpp.obj
+[24/35] Building CXX object CMakeFiles\Finestray.dir\src\Log.cpp.obj
+[25/35] Building CXX object CMakeFiles\Finestray.dir\src\TrayIcon.cpp.obj
+[26/35] Building CXX object CMakeFiles\Finestray.dir\src\WindowInfo.cpp.obj
+[27/35] Building CXX object CMakeFiles\Finestray.dir\src\Path.cpp.obj
+[28/35] Building CXX object CMakeFiles\Finestray.dir\src\SettingsDialog.cpp.obj
+[29/35] Building CXX object CMakeFiles\Finestray.dir\src\Hotkey.cpp.obj
+[30/35] Building CXX object CMakeFiles\Finestray.dir\src\StringUtility.cpp.obj
+[31/35] Building CXX object CMakeFiles\Finestray.dir\src\WindowTracker.cpp.obj
+[32/35] Building CXX object CMakeFiles\Finestray.dir\src\ContextMenu.cpp.obj
+[33/35] Building CXX object CMakeFiles\Finestray.dir\src\Settings.cpp.obj
+[34/35] Building CXX object CMakeFiles\Finestray.dir\src\Finestray.cpp.obj
+[35/35] Linking CXX executable Finestray.exe
 **********************************************************************
 ** Visual Studio 2022 Developer Command Prompt v17.14.29
 ** Copyright (c) 2025 Microsoft Corporation
@@ -64,11 +84,147 @@ C:\apps\src\finestray\build\ninja-msvc\Debug>set VSTUDIO_INSTALL_DIR=C:\Program 
 -- Configuring done (0.5s)
 -- Generating done (0.1s)
 -- Build files have been written to: C:/apps/src/finestray/build/ninja-msvc/Release
-[1/29] Building RC object CMakeFiles\Finestray.dir\src\Finestray.rc.res
-[2/29] Scanning C:\apps\src\finestray\src\Helpers.cpp for CXX dependencies
-[3/29] Scanning C:\apps\src\finestray\src\ContextMenu.cpp for CXX dependencies
-[4/29] Scanning C:\apps\src\finestray\src\Path.cpp for CXX dependencies
-[5/29] Scanning C:\apps\src\finestray\src\SettingsDialog.cpp for CXX dependencies
-[6/29] Scanning C:\apps\src\finestray\src\Finestray.cpp for CXX dependencies
-[7/29] Scanning C:\apps\src\finestray\src\Settings.cpp for CXX dependencies
-[8/29] Generating CXX dyndep file CMakeFiles\Finestray.dir\CXX.dd
+[1/39] Scanning C:\apps\src\finestray\src\File.cpp for CXX dependencies
+[2/39] Scanning C:\apps\src\finestray\src\Log.cpp for CXX dependencies
+[3/39] Scanning C:\apps\src\finestray\src\Helpers.cpp for CXX dependencies
+[4/39] Scanning C:\apps\src\finestray\src\Bitmap.cpp for CXX dependencies
+[5/39] Scanning C:\apps\src\finestray\src\TrayIcon.cpp for CXX dependencies
+[6/39] Scanning C:\apps\src\finestray\src\Modifiers.cpp for CXX dependencies
+[7/39] Scanning C:\apps\src\finestray\src\Hotkey.cpp for CXX dependencies
+[8/39] Scanning C:\apps\src\finestray\src\AboutDialog.cpp for CXX dependencies
+[9/39] Scanning C:\apps\src\finestray\src\SettingsDialog.cpp for CXX dependencies
+[10/39] Scanning C:\apps\src\finestray\src\WindowInfo.cpp for CXX dependencies
+[11/39] Scanning C:\apps\src\finestray\src\StringUtility.cpp for CXX dependencies
+[12/39] Scanning C:\apps\src\finestray\src\Path.cpp for CXX dependencies
+[13/39] Scanning C:\apps\src\finestray\src\ContextMenu.cpp for CXX dependencies
+[14/39] Scanning C:\apps\src\finestray\src\WindowTracker.cpp for CXX dependencies
+[15/39] Scanning C:\apps\src\finestray\src\Settings.cpp for CXX dependencies
+[16/39] Scanning C:\apps\src\finestray\src\Finestray.cpp for CXX dependencies
+[17/39] Building RC object CMakeFiles\Finestray.dir\src\Finestray.rc.res
+[18/39] Generating CXX dyndep file CMakeFiles\Finestray.dir\CXX.dd
+[19/35] Building CXX object CMakeFiles\Finestray.dir\src\Log.cpp.obj
+[20/35] Building CXX object CMakeFiles\Finestray.dir\src\File.cpp.obj
+[21/35] Building CXX object CMakeFiles\Finestray.dir\src\Helpers.cpp.obj
+[22/35] Building CXX object CMakeFiles\Finestray.dir\src\Modifiers.cpp.obj
+[23/35] Building CXX object CMakeFiles\Finestray.dir\src\Bitmap.cpp.obj
+[24/35] Building CXX object CMakeFiles\Finestray.dir\src\AboutDialog.cpp.obj
+[25/35] Building CXX object CMakeFiles\Finestray.dir\src\TrayIcon.cpp.obj
+[26/35] Building CXX object CMakeFiles\Finestray.dir\src\Path.cpp.obj
+[27/35] Building CXX object CMakeFiles\Finestray.dir\src\WindowInfo.cpp.obj
+[28/35] Building CXX object CMakeFiles\Finestray.dir\src\SettingsDialog.cpp.obj
+[29/35] Building CXX object CMakeFiles\Finestray.dir\src\StringUtility.cpp.obj
+[30/35] Building CXX object CMakeFiles\Finestray.dir\src\Hotkey.cpp.obj
+[31/35] Building CXX object CMakeFiles\Finestray.dir\src\ContextMenu.cpp.obj
+[32/35] Building CXX object CMakeFiles\Finestray.dir\src\WindowTracker.cpp.obj
+[33/35] Building CXX object CMakeFiles\Finestray.dir\src\Settings.cpp.obj
+[34/35] Building CXX object CMakeFiles\Finestray.dir\src\Finestray.cpp.obj
+[35/35] Linking CXX executable Finestray.exe
+[0/1] Run CPack packaging tool...
+CPack: Create package using NSIS64
+CPack: Install projects
+CPack: - Install project: Finestray []
+CPack: Create package
+CPack: - package: C:/apps/src/finestray/build/ninja-msvc/Release/Finestray-0.5-win64.exe generated.
+**********************************************************************
+** Visual Studio 2022 Developer Command Prompt v17.14.29
+** Copyright (c) 2025 Microsoft Corporation
+**********************************************************************
+[vcvarsall.bat] Environment initialized for: 'x64'
+-- Configuring done (0.5s)
+-- Generating done (0.1s)
+-- Build files have been written to: C:/apps/src/finestray/build/ninja-msvc/Analyze
+[1/39] Scanning C:\apps\src\finestray\src\File.cpp for CXX dependencies
+[2/39] Scanning C:\apps\src\finestray\src\Log.cpp for CXX dependencies
+[3/39] Scanning C:\apps\src\finestray\src\Bitmap.cpp for CXX dependencies
+[4/39] Scanning C:\apps\src\finestray\src\SettingsDialog.cpp for CXX dependencies
+[5/39] Scanning C:\apps\src\finestray\src\Helpers.cpp for CXX dependencies
+[6/39] Scanning C:\apps\src\finestray\src\AboutDialog.cpp for CXX dependencies
+[7/39] Scanning C:\apps\src\finestray\src\Modifiers.cpp for CXX dependencies
+[8/39] Scanning C:\apps\src\finestray\src\StringUtility.cpp for CXX dependencies
+[9/39] Scanning C:\apps\src\finestray\src\Hotkey.cpp for CXX dependencies
+[10/39] Scanning C:\apps\src\finestray\src\Path.cpp for CXX dependencies
+[11/39] Building RC object CMakeFiles\Finestray.dir\src\Finestray.rc.res
+[12/39] Scanning C:\apps\src\finestray\src\ContextMenu.cpp for CXX dependencies
+[13/39] Scanning C:\apps\src\finestray\src\Settings.cpp for CXX dependencies
+[14/39] Scanning C:\apps\src\finestray\src\Finestray.cpp for CXX dependencies
+[15/39] Scanning C:\apps\src\finestray\src\TrayIcon.cpp for CXX dependencies
+[16/39] Scanning C:\apps\src\finestray\src\WindowInfo.cpp for CXX dependencies
+[17/39] Scanning C:\apps\src\finestray\src\WindowTracker.cpp for CXX dependencies
+[18/39] Generating CXX dyndep file CMakeFiles\Finestray.dir\CXX.dd
+[19/35] Building CXX object CMakeFiles\Finestray.dir\src\File.cpp.obj
+[20/35] Building CXX object CMakeFiles\Finestray.dir\src\Helpers.cpp.obj
+[21/35] Building CXX object CMakeFiles\Finestray.dir\src\Modifiers.cpp.obj
+[22/35] Building CXX object CMakeFiles\Finestray.dir\src\Bitmap.cpp.obj
+[23/35] Building CXX object CMakeFiles\Finestray.dir\src\AboutDialog.cpp.obj
+[24/35] Building CXX object CMakeFiles\Finestray.dir\src\Log.cpp.obj
+[25/35] Building CXX object CMakeFiles\Finestray.dir\src\TrayIcon.cpp.obj
+[26/35] Building CXX object CMakeFiles\Finestray.dir\src\WindowInfo.cpp.obj
+[27/35] Building CXX object CMakeFiles\Finestray.dir\src\Path.cpp.obj
+[28/35] Building CXX object CMakeFiles\Finestray.dir\src\StringUtility.cpp.obj
+[29/35] Building CXX object CMakeFiles\Finestray.dir\src\SettingsDialog.cpp.obj
+[30/35] Building CXX object CMakeFiles\Finestray.dir\src\Hotkey.cpp.obj
+[31/35] Building CXX object CMakeFiles\Finestray.dir\src\ContextMenu.cpp.obj
+[32/35] Building CXX object CMakeFiles\Finestray.dir\src\WindowTracker.cpp.obj
+[33/35] Building CXX object CMakeFiles\Finestray.dir\src\Settings.cpp.obj
+[34/35] Building CXX object CMakeFiles\Finestray.dir\src\Finestray.cpp.obj
+[35/35] Linking CXX executable Finestray.exe
+**********************************************************************
+** Visual Studio 2022 Developer Command Prompt v17.14.29
+** Copyright (c) 2025 Microsoft Corporation
+**********************************************************************
+[vcvarsall.bat] Environment initialized for: 'x64'
+-- Configuring done (0.5s)
+-- Generating done (0.1s)
+-- Build files have been written to: C:/apps/src/finestray/build/ninja-clang/Debug
+[1/38] Scanning C:/apps/src/finestray/src/AboutDialog.cpp for CXX dependencies
+[2/38] Scanning C:/apps/src/finestray/src/Bitmap.cpp for CXX dependencies
+[3/38] Scanning C:/apps/src/finestray/src/Helpers.cpp for CXX dependencies
+[4/38] Scanning C:/apps/src/finestray/src/Hotkey.cpp for CXX dependencies
+[5/38] Scanning C:/apps/src/finestray/src/File.cpp for CXX dependencies
+[6/38] Scanning C:/apps/src/finestray/src/ContextMenu.cpp for CXX dependencies
+[7/38] Scanning C:/apps/src/finestray/src/Log.cpp for CXX dependencies
+[8/38] Scanning C:/apps/src/finestray/src/Finestray.cpp for CXX dependencies
+[9/38] Scanning C:/apps/src/finestray/src/Modifiers.cpp for CXX dependencies
+[10/38] Scanning C:/apps/src/finestray/src/Path.cpp for CXX dependencies
+[11/38] Scanning C:/apps/src/finestray/src/WindowInfo.cpp for CXX dependencies
+[12/38] Scanning C:/apps/src/finestray/src/Settings.cpp for CXX dependencies
+[13/38] Scanning C:/apps/src/finestray/src/SettingsDialog.cpp for CXX dependencies
+[14/38] Scanning C:/apps/src/finestray/src/TrayIcon.cpp for CXX dependencies
+[15/38] Scanning C:/apps/src/finestray/src/WindowTracker.cpp for CXX dependencies
+[16/38] Scanning C:/apps/src/finestray/src/StringUtility.cpp for CXX dependencies
+[17/38] Generating CXX dyndep file CMakeFiles/Finestray.dir/CXX.dd
+[18/34] Building CXX object CMakeFiles/Finestray.dir/src/AboutDialog.cpp.obj
+[19/34] Building CXX object CMakeFiles/Finestray.dir/src/File.cpp.obj
+[20/34] Building CXX object CMakeFiles/Finestray.dir/src/Bitmap.cpp.obj
+[21/34] Building CXX object CMakeFiles/Finestray.dir/src/Modifiers.cpp.obj
+[22/34] Building CXX object CMakeFiles/Finestray.dir/src/Helpers.cpp.obj
+[23/34] Building CXX object CMakeFiles/Finestray.dir/src/Log.cpp.obj
+[24/34] Building CXX object CMakeFiles/Finestray.dir/src/Path.cpp.obj
+[25/34] Building CXX object CMakeFiles/Finestray.dir/src/Hotkey.cpp.obj
+[26/34] Building CXX object CMakeFiles/Finestray.dir/src/WindowInfo.cpp.obj
+[27/34] Building CXX object CMakeFiles/Finestray.dir/src/TrayIcon.cpp.obj
+[28/34] Building CXX object CMakeFiles/Finestray.dir/src/ContextMenu.cpp.obj
+[29/34] Building CXX object CMakeFiles/Finestray.dir/src/SettingsDialog.cpp.obj
+[30/34] Building CXX object CMakeFiles/Finestray.dir/src/StringUtility.cpp.obj
+[31/34] Building CXX object CMakeFiles/Finestray.dir/src/WindowTracker.cpp.obj
+[32/34] Building CXX object CMakeFiles/Finestray.dir/src/Settings.cpp.obj
+[33/34] Building CXX object CMakeFiles/Finestray.dir/src/Finestray.cpp.obj
+[34/34] Linking CXX executable Finestray.exe
+**********************************************************************
+** Visual Studio 2022 Developer Command Prompt v17.14.29
+** Copyright (c) 2025 Microsoft Corporation
+**********************************************************************
+[vcvarsall.bat] Environment initialized for: 'x64'
+-- The C compiler identification is Clang 19.1.5 with GNU-like command-line
+-- The CXX compiler identification is Clang 19.1.5 with GNU-like command-line
+-- Detecting C compiler ABI info
+-- Detecting C compiler ABI info - done
+-- Check for working C compiler: C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/Llvm/x64/bin/clang.exe - skipped
+-- Detecting C compile features
+-- Detecting C compile features - done
+-- Detecting CXX compiler ABI info
+-- Detecting CXX compiler ABI info - done
+-- Check for working CXX compiler: C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/Llvm/x64/bin/clang.exe - skipped
+-- Detecting CXX compile features
+-- Detecting CXX compile features - done
+-- Found Patch: C:/Program Files/Git/usr/bin/patch.exe

--- a/src/AppInfo.h
+++ b/src/AppInfo.h
@@ -15,8 +15,8 @@
 #pragma once
 
 #define APP_NAME "Finestray"
-#define APP_VERSION 0, 4, 0, 0
-#define APP_VERSION_STRING "0.4.0.0"
-#define APP_VERSION_STRING_SIMPLE "0.4"
-#define APP_DATE "2025-05-21"
+#define APP_VERSION 0, 5, 0, 0
+#define APP_VERSION_STRING "0.5.0.0"
+#define APP_VERSION_STRING_SIMPLE "0.5"
+#define APP_DATE "2026-03-26"
 #define APP_COPYRIGHT "Copyright 2020 Benbuck Nason"

--- a/src/ContextMenu.cpp
+++ b/src/ContextMenu.cpp
@@ -27,6 +27,8 @@
 #include "WindowInfo.h"
 #include "WindowTracker.h"
 
+extern VirtualDesktopHelper g_vdHelper;
+
 namespace
 {
 
@@ -74,7 +76,7 @@ bool show(HWND hwnd, MinimizePlacement minimizePlacement)
 
     if (minimizePlacementIncludesMenu(minimizePlacement)) {
         WindowTracker::enumerate([&](const WindowTracker::Item & item) {
-            if (item.visible_) {
+            if (g_vdHelper.IsOnCurrentDesktop(item.hwnd_) && (item.visible_)) {
                 visibleWindows_.push_back(item.hwnd_);
             } else if (item.minimized_) {
                 minimizedWindows_.push_back(item.hwnd_);
@@ -310,7 +312,7 @@ bool addMenuItemForWindow(HMENU menu, HWND hwnd, unsigned int id, const BitmapHa
 {
     std::string title = WindowInfo::getTitle(hwnd);
     constexpr size_t maxTitleLength = 30;
-    if (title.length() < 1) {
+    if (title.length() < 1 || title == "Windows Virtual Desktop Manager") {
         return true;
     }
     if (title.length() > maxTitleLength) {

--- a/src/ContextMenu.cpp
+++ b/src/ContextMenu.cpp
@@ -27,8 +27,6 @@
 #include "WindowInfo.h"
 #include "WindowTracker.h"
 
-extern VirtualDesktopHelper g_vdHelper;
-
 namespace
 {
 

--- a/src/ContextMenu.cpp
+++ b/src/ContextMenu.cpp
@@ -310,6 +310,9 @@ bool addMenuItemForWindow(HMENU menu, HWND hwnd, unsigned int id, const BitmapHa
 {
     std::string title = WindowInfo::getTitle(hwnd);
     constexpr size_t maxTitleLength = 30;
+    if (title.length() < 1) {
+        return true;
+    }
     if (title.length() > maxTitleLength) {
         const std::string_view ellipsis = "...";
         title.resize(maxTitleLength - ellipsis.length());

--- a/src/Finestray.cpp
+++ b/src/Finestray.cpp
@@ -109,6 +109,7 @@ Hotkey hotkeyMenu_;
 UINT modifiersOverride_;
 UINT taskbarCreatedMessage_;
 UINT shellHookMsg_;
+std::vector<std::regex> compiledAutoTrayRegexes_;
 
 } // anonymous namespace
 
@@ -674,13 +675,18 @@ ErrorContext start()
         return { IDS_ERROR_REGISTER_MODIFIER, "override" };
     }
 
-    // check auto-tray regular expressions to surface an error if needed
+    // check auto-tray regular expressions and build compiled regex cache
+    compiledAutoTrayRegexes_.clear();
+    compiledAutoTrayRegexes_.reserve(settings_.autoTrays_.size());
     for (const Settings::AutoTray & autoTray : settings_.autoTrays_) {
-        try {
-            const std::regex re(autoTray.windowTitle_);
-            static_cast<void>(re);
-        } catch (const std::regex_error & e) {
-            return { IDS_ERROR_PARSE_REGEX, "'" + autoTray.windowTitle_ + "': " + e.what() };
+        if (autoTray.windowTitle_.empty()) {
+            compiledAutoTrayRegexes_.emplace_back();
+        } else {
+            try {
+                compiledAutoTrayRegexes_.emplace_back(autoTray.windowTitle_);
+            } catch (const std::regex_error & e) {
+                return { IDS_ERROR_PARSE_REGEX, "'" + autoTray.windowTitle_ + "': " + e.what() };
+            }
         }
     }
 
@@ -714,7 +720,12 @@ bool windowShouldAutoTray(HWND hwnd, TrayEvent trayEvent, MinimizePersistence * 
     DEBUG_PRINTF("\ttitle: '%s'\n", windowInfo.title().c_str());
     DEBUG_PRINTF("\tclass: '%s'\n", windowInfo.className().c_str());
 
-    for (const Settings::AutoTray & autoTray : settings_.autoTrays_) {
+    // executable_ is pre-lowercased in Settings::normalize(), so only lowercase once here
+    const std::string executableLower = StringUtility::toLower(windowInfo.executable());
+
+    for (size_t i = 0; i < settings_.autoTrays_.size(); ++i) {
+        const Settings::AutoTray & autoTray = settings_.autoTrays_[i];
+
         bool classMatch = false;
         if (autoTray.windowClass_.empty()) {
             // DEBUG_PRINTF("\twindow class match (empty)\n");
@@ -735,7 +746,7 @@ bool windowShouldAutoTray(HWND hwnd, TrayEvent trayEvent, MinimizePersistence * 
             // DEBUG_PRINTF("\texecutable match (empty)\n");
             executableMatch = true;
         } else {
-            if (StringUtility::toLower(autoTray.executable_) == StringUtility::toLower(windowInfo.executable())) {
+            if (autoTray.executable_ == executableLower) {
                 // DEBUG_PRINTF("\texecutable '%s' match\n", autoTray.executable_.c_str());
                 executableMatch = true;
             }
@@ -749,10 +760,9 @@ bool windowShouldAutoTray(HWND hwnd, TrayEvent trayEvent, MinimizePersistence * 
         if (autoTray.windowTitle_.empty()) {
             // DEBUG_PRINTF("\twindow title match (empty)\n");
             titleMatch = true;
-        } else {
+        } else if (i < compiledAutoTrayRegexes_.size()) {
             try {
-                const std::regex re(autoTray.windowTitle_);
-                if (std::regex_match(windowInfo.title(), re)) {
+                if (std::regex_match(windowInfo.title(), compiledAutoTrayRegexes_[i])) {
                     // DEBUG_PRINTF("\twindow title '%s' match\n", autoTray.windowTitle_.c_str());
                     titleMatch = true;
                 }

--- a/src/Finestray.cpp
+++ b/src/Finestray.cpp
@@ -46,6 +46,7 @@
 #include <WinUser.h>
 #include <Windows.h>
 
+
 // Standard library
 #include <cassert>
 #include <ranges>
@@ -53,6 +54,8 @@
 #include <string>
 #include <string_view>
 #include <vector>
+
+VirtualDesktopHelper g_vdHelper;
 
 namespace
 {
@@ -182,6 +185,12 @@ int WINAPI wWinMain(_In_ HINSTANCE hinstance, _In_opt_ HINSTANCE hPrevInstance, 
     settings_.dump();
 
     IconHandleWrapper icon(LoadIcon(hinstance, MAKEINTRESOURCE(IDI_FINESTRAY)), IconHandleWrapper::Mode::Referenced);
+
+    DEBUG_PRINTF("initializing virtual desktop helper\n");
+    if (!g_vdHelper.Init())
+    {
+        ERROR_PRINTF("could not initialize virtual desktop helper\n");
+    }
 
     DEBUG_PRINTF("registering window class\n");
     WNDCLASSEXA wc;

--- a/src/Helpers.h
+++ b/src/Helpers.h
@@ -19,7 +19,7 @@
 
 // Windows
 #include <Windows.h>
-#include <shobjidl.h>
+#include <ShObjIdl.h>
 #include <comdef.h>
 
 // Standard library
@@ -41,10 +41,6 @@ void errorMessage(const ErrorContext & errorContext);
 
 // RAII wrapper that creates the IVirtualDesktopManager once and
 // caches it for the lifetime of the object (typically your app).
-#include <Windows.h>
-#include <shobjidl.h>
-#include <comdef.h>
-
 class VirtualDesktopHelper
 {
 public:
@@ -151,3 +147,5 @@ private:
     bool                    m_comReady;
     IVirtualDesktopManager* m_pVDM;
 };
+
+extern VirtualDesktopHelper g_vdHelper;

--- a/src/Helpers.h
+++ b/src/Helpers.h
@@ -19,6 +19,8 @@
 
 // Windows
 #include <Windows.h>
+#include <shobjidl.h>
+#include <comdef.h>
 
 // Standard library
 #include <string>
@@ -36,3 +38,116 @@ bool isWindowStealth(HWND hwnd) noexcept;
 bool isWindowUserVisible(HWND hwnd) noexcept;
 void errorMessage(unsigned int id);
 void errorMessage(const ErrorContext & errorContext);
+
+// RAII wrapper that creates the IVirtualDesktopManager once and
+// caches it for the lifetime of the object (typically your app).
+#include <Windows.h>
+#include <shobjidl.h>
+#include <comdef.h>
+
+class VirtualDesktopHelper
+{
+public:
+    VirtualDesktopHelper() : m_comReady(false), m_pVDM(nullptr) {}
+
+    ~VirtualDesktopHelper()
+    {
+        if (m_pVDM)
+            m_pVDM->Release();
+
+        if (m_comReady)
+            ::CoUninitialize();
+    }
+
+    VirtualDesktopHelper(const VirtualDesktopHelper&) = delete;
+    VirtualDesktopHelper& operator=(const VirtualDesktopHelper&) = delete;
+
+    bool Init()
+    {
+        HRESULT hr = ::CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
+        m_comReady = SUCCEEDED(hr);
+        if (FAILED(hr) && hr == RPC_E_CHANGED_MODE)
+            m_comReady = true;
+
+        if (!m_comReady)
+            return false;
+
+        hr = ::CoCreateInstance(
+            CLSID_VirtualDesktopManager,
+            nullptr,
+            CLSCTX_ALL,
+            IID_IVirtualDesktopManager,
+            reinterpret_cast<void**>(&m_pVDM));
+
+        return SUCCEEDED(hr) && m_pVDM;
+    }
+
+    bool IsOnCurrentDesktop(HWND hwnd) const
+    {
+        if (!m_pVDM || !hwnd || !::IsWindow(hwnd))
+            return false;
+
+        if (!::IsWindowVisible(hwnd))
+            return false;
+
+        // Get the window's desktop GUID via COM.
+        // (This is a property of the window itself, so it doesn't
+        // suffer from the same staleness problem.)
+        GUID windowDesktopId = {};
+        HRESULT hr = m_pVDM->GetWindowDesktopId(hwnd, &windowDesktopId);
+        if (FAILED(hr))
+            return false;
+
+        // A zero GUID means the window is pinned to all desktops
+        // (e.g. sticky notes, Task Manager when "show on all desktops").
+        if (::IsEqualGUID(windowDesktopId, GUID_NULL))
+            return true;
+
+        // Read the current desktop GUID straight from the registry.
+        // This value is updated by Explorer instantly on switch,
+        // before the COM proxy catches up.
+        GUID currentDesktopId = {};
+        if (!GetCurrentDesktopIdFromRegistry(currentDesktopId))
+            return false;
+
+        return ::IsEqualGUID(windowDesktopId, currentDesktopId);
+    }
+
+private:
+    static bool GetCurrentDesktopIdFromRegistry(GUID& desktopId)
+    {
+        HKEY hKey = nullptr;
+        LONG rc = ::RegOpenKeyExW(
+            HKEY_CURRENT_USER,
+            L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\VirtualDesktops",
+            0,
+            KEY_READ,
+            &hKey);
+
+        if (rc != ERROR_SUCCESS)
+            return false;
+
+        BYTE data[16] = {};   // A GUID is exactly 16 bytes
+        DWORD dataSize = sizeof(data);
+        DWORD type = 0;
+
+        rc = ::RegQueryValueExW(
+            hKey,
+            L"CurrentVirtualDesktop",
+            nullptr,
+            &type,
+            data,
+            &dataSize);
+
+        ::RegCloseKey(hKey);
+
+        if (rc != ERROR_SUCCESS || type != REG_BINARY || dataSize != 16)
+            return false;
+
+        ::memcpy(&desktopId, data, 16);
+        return true;
+    }
+
+    bool                    m_comReady;
+    IVirtualDesktopManager* m_pVDM;
+};

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -309,6 +309,8 @@ void Settings::normalize()
             continue;
         }
 
+        autoTray.executable_ = StringUtility::toLower(autoTray.executable_);
+
         if (autoTray.trayEvent_ == TrayEvent::None) {
             DEBUG_PRINTF("Changing auto-tray item with no event to minimize\n");
             autoTray.trayEvent_ = TrayEvent::Minimize;

--- a/src/WindowTracker.cpp
+++ b/src/WindowTracker.cpp
@@ -26,8 +26,8 @@
 #include <cassert>
 #include <list>
 #include <memory>
-#include <ranges>
 #include <string>
+#include <unordered_map>
 
 namespace
 {
@@ -36,6 +36,7 @@ typedef std::list<WindowTracker::Item> Items;
 
 HWND messageHwnd_;
 Items items_;
+std::unordered_map<HWND, Items::iterator> itemIndex_;
 bool enumerating_;
 
 Items::iterator findWindow(HWND hwnd);
@@ -60,6 +61,7 @@ void stop() noexcept
 
     assert(!enumerating_);
     items_.clear();
+    itemIndex_.clear();
 
     messageHwnd_ = nullptr;
 }
@@ -90,6 +92,7 @@ void windowDestroyed(HWND hwnd)
         return;
     }
 
+    itemIndex_.erase(hwnd);
     items_.erase(it);
 
     DEBUG_PRINTF("window destroyed: %zu items remaining\n", items_.size());
@@ -172,6 +175,7 @@ void minimize(HWND hwnd, MinimizePlacement minimizePlacement, MinimizePersistenc
     // move item to end of list so restore order is reverse of minimize order
     items_.push_back(item);
     items_.erase(it);
+    itemIndex_[hwnd] = std::prev(items_.end());
 }
 
 void restore(HWND hwnd)
@@ -209,6 +213,7 @@ void restore(HWND hwnd)
     // move item to front of list so next restore is in reverse order of minimize
     items_.push_front(item);
     items_.erase(it);
+    itemIndex_[hwnd] = items_.begin();
 }
 
 void addAllMinimizedToTray(MinimizePlacement minimizePlacement)
@@ -310,9 +315,10 @@ Items::iterator findWindow(HWND hwnd)
 {
     assert(!enumerating_);
 
-    return std::ranges::find_if(items_, [hwnd](const WindowTracker::Item & item) {
-        return item.hwnd_ == hwnd;
-    });
+    const auto mapIt = itemIndex_.find(hwnd);
+    if (mapIt == itemIndex_.end())
+        return items_.end();
+    return mapIt->second;
 }
 
 void addItem(HWND hwnd) noexcept
@@ -328,6 +334,7 @@ void addItem(HWND hwnd) noexcept
     item.title_ = title;
     item.visible_ = visible;
     items_.push_back(item);
+    itemIndex_[hwnd] = std::prev(items_.end());
 }
 
 void updateItem(WindowTracker::Item & item, HWND hwnd) noexcept


### PR DESCRIPTION
This patch makes finestray virtual-desktop aware, so that the popup menu is only populated with visible menus that are actually "visible," i.e. present on the currently active desktop. I've been testing this for a day without seeing any downside but will continue to test. This could be modified to make virtual desktop awareness an optional setting.

I also did a bunch of small clean-up/optimizations, which ended up getting noted here as "update version to 0.5". Nothing major and hopefully not controversial.